### PR TITLE
chore(fix): update cog.toml to ignore merge commits

### DIFF
--- a/cog.toml
+++ b/cog.toml
@@ -1,5 +1,6 @@
 from_latest_tag = false
 branch_whitelist = ["main"]
+ignore_merge_commits = true
 
 [changelog]
 path = "CHANGELOG.md"


### PR DESCRIPTION
<!--
Title guideline:
<type>(<scope>): <short description>

Examples:
feat(quic): fix handshake retry loop
fix(crypto): rotate noise key schedule
docs(adr): add ADR on NAT traversal
-->

## Summary

Emergency fix to the CI pipeline to not commit lint GitHub's auto generated Merge commits.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Cleanup
- [ ] Performance
- [ ] Security
- [x] Documentation / Tooling / CI

## Linked Work

- Closes: N/A
- ADR(s): N/A
- Related PRs: N/A

---

## Reviewer Notes

- Suggested reviewers: @samratsb
- Preferred read order (if multiple files/commits otherwise N/A): N/A

## Release and Docs

- **Breaking change?** - [x] No - [ ] Yet -- describe impact and migration:
- **User-facing notes (1-2 lines for changelog):** Click Feature Request as an option when making an issue
- **Docs impact?** - [x] None - [ ] README/CLI/help updated - [ ] Follow-up issue: N/A
