### PR TITLE
docs: add architectural decision record template

### DIFF
--- a/docs/architecture/decisions/0000-adr-template.md
+++ b/docs/architecture/decisions/0000-adr-template.md
@@ -1,0 +1,68 @@
+# Architectural Decision Record-0000: Template
+
+## Header
+
+- **Status:** Proposed | Accepted | Rejected | Superseded by ADR-XXXX
+- **Date:** YYYY-MM-DD               <!-- UTC+0 -->
+- **Last-Updated:** YYYY-MM-DD       <!-- optional, UTC+0 -->
+- **Deciders:** <names>              <!-- optional -->
+- **Related ADRs:** ADR-..., ADR-... <!-- optional -->
+
+## Context
+<!-- What problem is being solved? Background, constrains, assumptions, non-goals. -->
+
+## Decision Drivers
+
+1. ...
+2. ...
+3. ...
+
+## Options
+
+### Option 1 - <Name>
+
+**Pros**
+
+- ...
+
+**Neutral** *(optional)*
+
+- ...
+
+**Cons**
+
+- ...
+
+<!-- Add more options as needed -->
+
+## Alternative Considerations
+
+## Decision
+<!-- Which option and why? -->
+
+## Rationale
+<!-- Key arguments and trade-offs that led to the choice. -->
+
+## Consequences
+
+### Positive
+
+- ...
+
+### Neutral *(optional)*
+
+- ...
+
+### Negative
+
+- ...
+
+### Mitigation
+
+- ...
+
+---
+
+## Follow-ups *(optional)*
+
+- ADR-XXXX - <short title>


### PR DESCRIPTION
<!--
Title guideline:
<type>(<scope>): <short description>

Examples:
feat(quic): fix handshake retry loop
fix(crypto): rotate noise key schedule
docs(adr): add ADR on NAT traversal
-->

## Summary

Adds the architectural decision record template, ADR-0000, and standardize all future ADRs.

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Cleanup
- [ ] Performance
- [ ] Security
- [x] Documentation / Tooling / CI

## Linked Work

- Closes #9 
- ADR(s): ADR-0000: Template
- Related PRs: N/A

---

## Reviewer Notes

- Suggested reviewers: @kobinabrandon 
- Preferred read order (if multiple files/commits otherwise N/A): N/A

## Release and Docs

- **Breaking change?** - [x] No - [ ] Yes -- describe impact and migration:
- **User-facing notes (1-2 lines for changelog):** Added ADR Template
- **Docs impact?** - [x] None - [ ] README/CLI/help updated - [ ] Follow-up issue: N/A
