### PR TITLE
feat: implement security fixes and add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "ashpd"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,7 +362,9 @@ name = "backend"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base32",
  "bitflags 2.9.4",
+ "blake3",
  "chrono",
  "ed25519-dalek",
  "hex",
@@ -360,10 +374,11 @@ dependencies = [
  "rcgen",
  "rustls",
  "serde",
+ "serial_test",
  "sha2",
  "thiserror 2.0.16",
  "tokio",
- "x509-parser",
+ "x509-parser 0.18.0",
  "zeroize",
 ]
 
@@ -381,6 +396,12 @@ dependencies = [
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base64"
@@ -407,6 +428,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "blake3"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -723,6 +757,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -4239,7 +4279,7 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "time",
- "x509-parser",
+ "x509-parser 0.17.0",
  "yasna",
 ]
 
@@ -4514,6 +4554,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4527,6 +4576,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -4693,6 +4748,31 @@ dependencies = [
  "itoa 1.0.15",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6531,6 +6611,23 @@ dependencies = [
  "nom",
  "oid-registry",
  "ring",
+ "rusticata-macros",
+ "thiserror 2.0.16",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3e137310115a65136898d2079f003ce33331a6c4b0d51f1531d1be082b6425"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
  "rusticata-macros",
  "thiserror 2.0.16",
  "time",

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -20,6 +20,7 @@ rand = "0.8"
 rcgen = { version = "0.14.3", default-features = false, features = ["x509-parser", "ring"] }
 rustls = { version = "0.23.31", default-features = false, features = ["ring", "std"] }
 serde = { version = "1.0.219", features = ["derive"] }
+serial_test = "3.2.0"
 sha2 = "0.10.9"
 thiserror = "2.0.16"
 tokio = { version = "1.47.1", features = ["macros", "rt", "time"] }

--- a/crates/backend/src/pinset/keychain.rs
+++ b/crates/backend/src/pinset/keychain.rs
@@ -144,15 +144,29 @@ impl KeyAttributes {
 }
 
 /// Securely stored key data with automatic zeroization
-#[derive(Clone)]
+// #[derive(Clone)]
 pub struct SecureKey {
     data: Zeroizing<Box<[u8]>>,
 }
 
 impl SecureKey {
-    pub fn new(data: impl AsRef<[u8]>) -> Self {
+    // pub fn new(data: impl AsRef<[u8]>) -> Self {
+    //     Self {
+    //         data: Zeroizing::new(data.as_ref().into()),
+    //     }
+    // }
+
+    /// Copy from a borrowed slice
+    pub fn from_slice(s: &[u8]) -> Self {
         Self {
-            data: Zeroizing::new(data.as_ref().into()),
+            data: Zeroizing::new(s.into()),
+        }
+    }
+
+    /// Move from an owned Vec without copying.
+    pub fn from_vec(v: Vec<u8>) -> Self {
+        Self {
+            data: Zeroizing::new(v.into_boxed_slice()),
         }
     }
 
@@ -179,17 +193,30 @@ impl fmt::Debug for SecureKey {
     }
 }
 
+// impl From<Vec<u8>> for SecureKey {
+//     fn from(data: Vec<u8>) -> Self {
+//         Self::new(data)
+//     }
+// }
+
+// impl From<&[u8]> for SecureKey {
+//     fn from(data: &[u8]) -> Self {
+//         Self::new(data)
+//     }
+// }
+
 impl From<Vec<u8>> for SecureKey {
-    fn from(data: Vec<u8>) -> Self {
-        Self::new(data)
+    fn from(v: Vec<u8>) -> Self {
+        SecureKey::from_vec(v)
     }
 }
 
 impl From<&[u8]> for SecureKey {
     fn from(data: &[u8]) -> Self {
-        Self::new(data)
+        Self::from_slice(data)
     }
 }
+
 /**
 Keychain implementation using the `keyring` crate
 
@@ -225,6 +252,7 @@ impl Keychain {
         let entry = self.create_entry(&attributes.identifier)?;
 
         // Check if key already exists
+        // !! .get_secret() might prompt a window open on some OS's
         if entry.get_secret().is_ok() {
             return Err(KeychainError::AlreadyExists(
                 attributes.identifier.to_string().into(),
@@ -235,9 +263,8 @@ impl Keychain {
         // Note: In the future, we should interact with our key_source flag here to know
         // if we want a passphrase KDF (i.e., the user sets a password to encrypt the file).
         // For now, we use get_secret/set_secret with hex encoding for reliable binary storage.
-        let hex_encoded = hex::encode(key.as_bytes());
         entry
-            .set_secret(hex_encoded.as_bytes())
+            .set_secret(key.as_bytes())
             .map_err(KeychainError::from)
     }
 
@@ -247,19 +274,9 @@ impl Keychain {
 
         let entry = self.create_entry(identifier)?;
 
-        // Retrieve the secret as bytes (hex-encoded)
-        let hex_bytes = entry.get_secret().map_err(KeychainError::from)?;
+        let bytes = entry.get_secret().map_err(KeychainError::from)?;
 
-        // Convert bytes to string and decode hex
-        let hex_str = std::str::from_utf8(&hex_bytes).map_err(|e| {
-            KeychainError::Keyring(format!("Invalid UTF-8 in stored hex: {e}").into())
-        })?;
-
-        let decoded = hex::decode(hex_str).map_err(|e| {
-            KeychainError::Keyring(format!("Failed to decode stored key: {e}").into())
-        })?;
-
-        Ok(SecureKey::new(decoded))
+        Ok(SecureKey::from(bytes))
     }
 
     pub fn update_key(&self, key: SecureKey, attributes: KeyAttributes) -> KeychainResult<()> {
@@ -276,9 +293,8 @@ impl Keychain {
         }
 
         // Update the secret as hex-encoded bytes
-        let hex_encoded = hex::encode(key.as_bytes());
         entry
-            .set_secret(hex_encoded.as_bytes())
+            .set_secret(key.as_bytes())
             .map_err(KeychainError::from)
     }
 
@@ -298,6 +314,7 @@ impl Keychain {
 
         let entry = self.create_entry(identifier)?;
 
+        // !! .get_secret() might prompt a window open on some OS's
         match entry.get_secret() {
             Ok(_) => Ok(true),
             Err(keyring::Error::NoEntry) => Ok(false),
@@ -386,9 +403,7 @@ pub fn kek_identifier_for_store(store_id: &[u8; 16]) -> KeyIdentifier {
     let hash = blake3::hash(store_id);
 
     // Encode with base32 without padding to make it shorter and more readable
-    let encoded = base32::encode(base32::Alphabet::Crockford, hash.as_bytes())
-        .trim_end_matches('=')
-        .to_lowercase();
+    let encoded = base32::encode(base32::Alphabet::Crockford, hash.as_bytes()).to_lowercase();
 
     KeyIdentifier::new(
         "com.p2p-password-manager.pinset",
@@ -448,7 +463,8 @@ fn test_key_attributes_builder() {
 #[test]
 fn test_secure_key_creation() {
     let data = vec![1, 2, 3, 4, 5];
-    let key = SecureKey::new(data.clone());
+    // let key = SecureKey::new(data.clone());
+    let key = SecureKey::from_slice(&data);
 
     assert_eq!(key.as_bytes(), &data[..]);
     assert_eq!(key.len(), 5);
@@ -457,7 +473,8 @@ fn test_secure_key_creation() {
 
 #[test]
 fn test_secure_key_debug() {
-    let key = SecureKey::new(vec![1, 2, 3, 4, 5]);
+    // let key = SecureKey::new(vec![1, 2, 3, 4, 5]);
+    let key = SecureKey::from_vec(vec![1, 2, 3, 4, 5]);
     let debug_str = format!("{key:?}");
     assert!(debug_str.contains("REDACTED"));
     assert!(debug_str.contains("5 bytes"));
@@ -468,13 +485,15 @@ fn test_secure_key_debug() {
 #[test]
 fn test_secure_key_from_vec() {
     let data = vec![1, 2, 3];
-    let key: SecureKey = data.clone().into();
-    assert_eq!(key.as_bytes(), &data[..]);
+    let keep = data.clone();
+    let key: SecureKey = data.into();
+    assert_eq!(key.as_bytes(), &keep[..]);
 }
 
 #[test]
 fn test_secure_key_from_slice() {
     let data: &[u8] = &[1, 2, 3, 4];
+    // let key: SecureKey = data.into();
     let key: SecureKey = data.into();
     assert_eq!(key.as_bytes(), data);
 }
@@ -516,7 +535,8 @@ fn test_store_and_retrieve_key() {
     let keychain = Keychain::new().expect("Failed to create keychain");
 
     let test_data = vec![1, 2, 3, 4, 5, 6, 7, 8];
-    let key = SecureKey::new(test_data.clone());
+    // let key = SecureKey::new(test_data.clone());
+    let key = SecureKey::from_vec(test_data.clone());
 
     let identifier = KeyIdentifier::new(
         "com.p2p-password-manager.test".into(),
@@ -574,7 +594,8 @@ fn test_key_exists() {
     assert!(!exists.unwrap());
 
     // Store a key
-    let key = SecureKey::new(vec![1, 2, 3]);
+    // let key = SecureKey::new(vec![1, 2, 3]);
+    let key = SecureKey::from_vec(vec![1, 2, 3]);
     let attributes = KeyAttributes::new(identifier.clone());
     keychain
         .store_key(key, attributes)
@@ -604,14 +625,16 @@ fn test_update_key() {
     let _ = keychain.delete_key(&identifier);
 
     // Store initial key
-    let key1 = SecureKey::new(vec![1, 2, 3]);
+    // let key1 = SecureKey::new(vec![1, 2, 3]);
+    let key1 = SecureKey::from_vec(vec![1, 2, 3]);
     let attributes = KeyAttributes::new(identifier.clone());
     keychain
         .store_key(key1, attributes.clone())
         .expect("Failed to store key");
 
     // Update with new data
-    let key2 = SecureKey::new(vec![4, 5, 6]);
+    // let key2 = SecureKey::new(vec![4, 5, 6]);
+    let key2 = SecureKey::from_vec(vec![4, 5, 6]);
     let update_result = keychain.update_key(key2, attributes);
     assert!(
         update_result.is_ok(),
@@ -675,14 +698,16 @@ fn test_store_duplicate_key() {
     let _ = keychain.delete_key(&identifier);
 
     // Store first key
-    let key1 = SecureKey::new(vec![1, 2, 3]);
+    // let key1 = SecureKey::new(vec![1, 2, 3]);
+    let key1 = SecureKey::from_vec(vec![1, 2, 3]);
     let attributes = KeyAttributes::new(identifier.clone());
     keychain
         .store_key(key1, attributes.clone())
         .expect("Failed to store first key");
 
     // Try to store again with same identifier
-    let key2 = SecureKey::new(vec![4, 5, 6]);
+    // let key2 = SecureKey::new(vec![4, 5, 6]);
+    let key2 = SecureKey::from_vec(vec![4, 5, 6]);
     let result = keychain.store_key(key2, attributes);
     assert!(result.is_err());
     assert!(matches!(
@@ -709,7 +734,8 @@ fn test_update_nonexistent_key() {
     let _ = keychain.delete_key(&identifier);
 
     // Try to update non-existent key
-    let key = SecureKey::new(vec![1, 2, 3]);
+    // let key = SecureKey::new(vec![1, 2, 3]);
+    let key = SecureKey::from_vec(vec![1, 2, 3]);
     let attributes = KeyAttributes::new(identifier);
     let result = keychain.update_key(key, attributes);
     assert!(result.is_err());
@@ -722,7 +748,8 @@ fn test_binary_secret_storage() {
 
     // Test with binary data that's not valid UTF-8
     let binary_data = vec![0xFF, 0xFE, 0xFD, 0x00, 0x01, 0x02];
-    let key = SecureKey::new(binary_data.clone());
+    // let key = SecureKey::new(binary_data.clone());
+    let key = SecureKey::from_vec(binary_data.clone());
 
     let identifier = KeyIdentifier::new(
         "com.p2p-password-manager.test".into(),

--- a/crates/backend/tests/os_keychain.rs
+++ b/crates/backend/tests/os_keychain.rs
@@ -1,0 +1,66 @@
+// TODO: Gate Tests
+// #![cfg(feature = "os-keychain-tests")]
+#![cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+
+use backend::pinset::keychain::{KeyAttributes, KeyIdentifier, Keychain, SecureKey};
+use serial_test::serial;
+
+fn unique_id(prefix: &str) -> KeyIdentifier {
+    use rand::{Rng, distributions::Alphanumeric};
+    let suffix: String = rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(8)
+        .map(char::from)
+        .collect();
+    KeyIdentifier::new(
+        "com.p2p-password-manager.test".to_string(),
+        format!("{prefix}-{}-{suffix}", std::process::id()),
+    )
+}
+
+#[test]
+#[serial]
+fn raw_bytes_round_trip_including_nul_and_non_utf8() {
+    let kc = match Keychain::new() {
+        Ok(k) => k,
+        Err(_) => return,
+    };
+
+    let id = unique_id("raw-roundtrip");
+    let attrs = KeyAttributes::new(id.clone());
+
+    // Clean up
+    let _ = kc.delete_key(&id);
+
+    // Includes NULs and non-UTF-8
+    let data = vec![0x00, 0xff, 0x01, 0x00, 0xfe, 0x7f, 0x80, 0xc3, 0x28];
+    let key = SecureKey::from(data.clone());
+
+    kc.store_key(key, attrs).expect("store raw key");
+
+    let out = kc.retrieve_key(&id).expect("retrieve raw key");
+    assert_eq!(out.as_bytes(), &data[..]);
+
+    let _ = kc.delete_key(&id);
+}
+
+#[test]
+#[serial]
+fn update_preserves_raw_bytes() {
+    let kc = Keychain::new().unwrap();
+    let id = unique_id("raw-update");
+    let attrs = KeyAttributes::new(id.clone());
+    let _ = kc.delete_key(&id);
+
+    let v1 = vec![0x00, 0x01, 0xff];
+    kc.store_key(SecureKey::from(v1.clone()), attrs.clone())
+        .unwrap();
+
+    let v2 = vec![0xaa, 0xbb, 0x00, 0xcc];
+    kc.update_key(SecureKey::from(v2.clone()), attrs).unwrap();
+
+    let out = kc.retrieve_key(&id).unwrap();
+    assert_eq!(out.as_bytes(), &v2[..]);
+
+    let _ = kc.delete_key(&id);
+}


### PR DESCRIPTION
<!--
Title guideline:
<type>(<scope>): <short description>

Examples:
feat(quic): fix handshake retry loop
fix(crypto): rotate noise key schedule
docs(adr): add ADR on NAT traversal
-->

## Summary

- Remove encoding/decoding pathway in favor of raw bytes
- Removed padding trimming for base32 encoded kek identifier since CrockFord alphabet does not have padding
- Refactored SecureKey to avoid copying and have two constructors, from_slice and from_vec

## Type of change

- [x] Feature
- [x] Bug fix
- [ ] Refactor / Cleanup
- [ ] Performance
- [ ] Security
- [ ] Documentation / Tooling / CI

## Linked Work

- Closes N/A
- ADR(s): N/A
- Related PRs: #43 

---

## Reviewer Notes

- Suggested reviewers: @alexcu2718 
- Preferred read order (if multiple files/commits otherwise N/A): keychain.rs and then tests/os_keychain.rs

## Release and Docs

- **Breaking change?** - [x] No - [ ] Yes -- describe impact and migration:
- **User-facing notes (1-2 lines for changelog):** Remove encoding/decoding, removed padding trim on base32, secure key avoids copying now
- **Docs impact?** - [x] None - [ ] README/CLI/help updated - [ ] Follow-up issue: N/A
